### PR TITLE
FLUSH support

### DIFF
--- a/lib/visage-app.rb
+++ b/lib/visage-app.rb
@@ -30,6 +30,7 @@ module Visage
         # FIXME: make this configurable through file
         c['rrddir'] = ENV["RRDDIR"] ? Pathname.new(ENV["RRDDIR"]).expand_path : Pathname.new("/var/lib/collectd/rrd").expand_path
         c['types']  = ENV["TYPES"] ? Visage::Types.new(:filename => ENV["TYPES"]) : Visage::Types.new
+        c['unixsock'] = ENV["UNIXSOCK"] ? Pathname.new(ENV["UNIXSOCK"]).expand_path : false
       end
 
       # Load up the profiles.yaml. Creates it if it doesn't already exist.
@@ -113,7 +114,8 @@ module Visage
       start     = params[:start]
       finish    = params[:finish]
 
-      collectd = Visage::Collectd::JSON.new(:rrddir => Visage::Config.rrddir)
+      collectd = Visage::Collectd::JSON.new(:rrddir => Visage::Config.rrddir,
+                                            :unixsock => Visage::Config.unixsock)
       json = collectd.json(:host      => host,
                            :plugin    => plugin,
                            :instances => instances,

--- a/lib/visage-app/collectd/json.rb
+++ b/lib/visage-app/collectd/json.rb
@@ -44,23 +44,19 @@ module Visage
         start     = parse_time(opts[:start],  :default => (finish - 3600 || (Time.now - 3600).to_i))
         data      = []
 
-        if @unixsock then 
-          ids = ""
-          seperate_instances.each do |identifier|
-            ids = ids+" identifier=\"#{host}/#{plugin}/#{identifier}\""
-          end
-
-          socket = UNIXSocket.new(@unixsock)
-          socket.puts "FLUSH #{ids}"
-          line = socket.gets
-          socket.close
-        end
-
         Dir.glob(rrdglob).map do |rrdname|
           parts         = rrdname.gsub(/#{@rrddir}\//, '').split('/')
           host_name     = parts[0]
           plugin_name   = parts[1]
           instance_name = File.basename(parts[2], '.rrd')
+
+          if @unixsock then
+            socket = UNIXSocket.new(@unixsock)
+            socket.puts "FLUSH #{rrdname}"
+            line = socket.gets
+            socket.close
+          end
+
           rrd           = Errand.new(:filename => rrdname)
 
           data << {  :plugin => plugin_name, :instance => instance_name,

--- a/lib/visage-app/collectd/rrds.rb
+++ b/lib/visage-app/collectd/rrds.rb
@@ -21,6 +21,8 @@ module Visage
             glob = "{#{hosts}}"
           when Array
             glob = "{#{opts[:hosts].join(',')}}"
+          when String
+            glob = "#{hosts}"
           else
             glob = "*"
           end

--- a/lib/visage-app/public/javascripts/graph.js
+++ b/lib/visage-app/public/javascripts/graph.js
@@ -4,7 +4,7 @@ function setStacked(chart, stacking) {
         serie = chart.series[0];
 
         serie.chart.addSeries({
-            type: newType,
+            type: stacking ? 'area' : 'line',
             name: serie.name,
             color: serie.color,
             data: serie.options.data,

--- a/lib/visage-app/public/javascripts/graph.js
+++ b/lib/visage-app/public/javascripts/graph.js
@@ -1,3 +1,20 @@
+function setStacked(chart, stacking) {
+    for(var i=0;i<chart.series.length;i++)
+    {
+        serie = series[0];
+
+        serie.chart.addSeries({
+            type: newType,
+            name: serie.name,
+            color: serie.color,
+            data: serie.options.data,
+            stacking: stacking ? 'normal' : null, 
+        }, false);
+        
+        serie.remove();
+    }
+}
+
 function formatSeriesLabel(labels) {
     var host     = labels[0],
         plugin   = labels[1],
@@ -149,7 +166,8 @@ var VisageBase = new Class({
     options: {
         secureJSON: false,
         httpMethod: 'get',
-        live: false
+        live: false,
+	stacked: false
     },
     initialize: function(element, host, plugin, options) {
         this.parentElement  = element;
@@ -555,6 +573,23 @@ var VisageGraph = new Class({
             }
         });
 
+	var stackedToggler = new Element('input', {
+		'type': 'checkbox',
+		'id': this.parentElement + '-stacked',
+		'name': 'stacked',
+		'checked': this.options.stacked,
+		'events': {
+			'click': function() {
+				this.options.stacked = !this.options.stacked
+				setStacked(this.chart, this.options.stacked)
+			}.bind(this)
+		},
+		'styles': {
+			'margin-right': '4px',
+			'cursor': 'pointer'
+		}
+	});
+
         var liveLabel = new Element('label', {
             'for': this.parentElement + '-live',
             'html': 'Live',
@@ -565,6 +600,17 @@ var VisageGraph = new Class({
                 'cursor': 'pointer'
             }
         });
+
+	var stackedLabel = new Element('label', {
+		'for': this.parentElement + '-stacked',
+		'html': 'Stacked',
+		'styles': {
+			'font-family': 'sans-serif',
+			'font-size': '11px',
+			'margin-right': '8px', 
+			'cursor': 'pointer'
+		}
+	});
 
         var exportLink = new Element('a', {
             'href': this.dataURL(),
@@ -595,6 +641,8 @@ var VisageGraph = new Class({
         form.grab(exportLink)
         form.grab(liveToggler)
         form.grab(liveLabel)
+	form.grab(stackedToggler)
+	form.grab(stackedLabel)
         form.grab(select)
         container.grab(form, 'top')
     },

--- a/lib/visage-app/public/javascripts/graph.js
+++ b/lib/visage-app/public/javascripts/graph.js
@@ -1,7 +1,7 @@
 function setStacked(chart, stacking) {
     for(var i=0;i<chart.series.length;i++)
     {
-        serie = series[0];
+        serie = chart.series[0];
 
         serie.chart.addSeries({
             type: newType,


### PR DESCRIPTION
This pull request adds support for the collectd-unixsock plugin's FLUSH command. If you have an environment variable called UNIXSOCK defined, visage will attempt to use it the socket it points to. 
