### PR TITLE
Pull Debug Port from Environment

### DIFF
--- a/bin/visage-app
+++ b/bin/visage-app
@@ -4,7 +4,7 @@ require 'pathname'
 
 require 'socket'
 fqdn = Socket.gethostbyname(Socket.gethostname).first
-port = 9292
+port = Integer(ENV.fetch('VISAGE_PORT', 9292))
 $stdout.sync = true
 @root = (Pathname.new(__FILE__).parent.parent + 'lib').expand_path
 $: << @root.to_s

--- a/bin/visage-app
+++ b/bin/visage-app
@@ -4,7 +4,7 @@ require 'pathname'
 
 require 'socket'
 fqdn = Socket.gethostbyname(Socket.gethostname).first
-port = Integer(ENV.fetch('VISAGE_PORT', 9292))
+port = ENV.fetch('VISAGE_PORT', 9292)
 $stdout.sync = true
 @root = (Pathname.new(__FILE__).parent.parent + 'lib').expand_path
 $: << @root.to_s


### PR DESCRIPTION
Very simple one-line modification to pull the debug web server port from an environment variable if present.

The default behavior remains the same: run the debug web server on TCP port 9292

This is a useful feature within environments that have port 9292 already dedicated to another service.
