### PR TITLE
Update lib/visage-app/config/file.rb

### DIFF
--- a/lib/visage-app/config/file.rb
+++ b/lib/visage-app/config/file.rb
@@ -4,6 +4,8 @@
 require @root.join('lib/visage-app/config')
 require 'yaml'
 
+YAML::ENGINE.yamler = 'syck'
+
 module Visage
   class Config
     class File


### PR DESCRIPTION
with ruby 1.9.1 quick and dirty fix for YAML Parser.
This fixes following error:

sudo visage-app start
/usr/local/lib/ruby/1.9.1/psych.rb:203:in `parse': (/usr/local/lib/ruby/gems/1.9.1/gems/visage-app-2.1.0/lib/visage-app/config/profiles.yaml): control characters are not allowed at line 1 column 1 (Psych::SyntaxError)
        from /usr/local/lib/ruby/1.9.1/psych.rb:203:in`parse_stream'
        from /usr/local/lib/ruby/1.9.1/psych.rb:151:in `parse'
        from /usr/local/lib/ruby/1.9.1/psych.rb:127:in`load'
        from /usr/local/lib/ruby/1.9.1/psych.rb:297:in `block in load_file'
        from /usr/local/lib/ruby/1.9.1/psych.rb:297:in`open'
        from /usr/local/lib/ruby/1.9.1/psych.rb:297:in `load_file'
        from /usr/local/lib/ruby/gems/1.9.1/gems/visage-app-2.1.0/lib/visage-app/config/file.rb:33:in`load'
        from /usr/local/lib/ruby/gems/1.9.1/gems/visage-app-2.1.0/lib/visage-app/profile.rb:25:in `load'
        from /usr/local/lib/ruby/gems/1.9.1/gems/visage-app-2.1.0/lib/visage-app.rb:38:in`block in class:Application'
        from /usr/local/lib/ruby/gems/1.9.1/gems/sinatra-1.3.2/lib/sinatra/base.rb:1273:in `configure'
        from /usr/local/lib/ruby/gems/1.9.1/gems/visage-app-2.1.0/lib/visage-app.rb:30:in`class:Application'
        from /usr/local/lib/ruby/gems/1.9.1/gems/visage-app-2.1.0/lib/visage-app.rb:19:in `<module:Visage>'
        from /usr/local/lib/ruby/gems/1.9.1/gems/visage-app-2.1.0/lib/visage-app.rb:18:in`<top (required)>'
        from /usr/local/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /usr/local/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
        from /usr/local/lib/ruby/gems/1.9.1/gems/visage-app-2.1.0/bin/visage-app:17:in `<top (required)>'
        from /usr/local/bin/visage-app:23:in`load'
        from /usr/local/bin/visage-app:23:in `<main>'

PS better to fix incorrect YAML code and use latest engine (this is a quick fix)
