### PR TITLE
Return metrics from all hosts rather than the common set

### DIFF
--- a/lib/visage-app/collectd/rrds.rb
+++ b/lib/visage-app/collectd/rrds.rb
@@ -49,7 +49,7 @@ module Visage
           if (dametrics.length) == 1
             dametrics.first
           else
-            dametrics.reduce(:&)
+            dametrics.reduce(:|)
           end
 
           #else


### PR DESCRIPTION
Makes RRDs.metrics return the complete set of metrics from all hosts rather than just the common set across all hosts.

Useful when you are returning data from hosts with a dissimilar set of metrics.
