### PR TITLE
fix to make specs run under 1.9.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     visage-app (2.1.0)
       errand (= 0.7.3)
       haml (= 3.1.4)
+      rrd-ffi (= 0.2.12)
       sinatra (= 1.3.2)
       tilt (= 1.3.3)
       yajl-ruby (= 1.1.0)
@@ -11,6 +12,9 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (3.2.8)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
     builder (3.0.0)
     colorize (0.5.8)
     cucumber (1.1.9)
@@ -21,16 +25,22 @@ GEM
       term-ansicolor (>= 1.0.6)
     diff-lcs (1.1.3)
     errand (0.7.3)
+    ffi (1.1.5)
     gherkin (2.9.1)
       json (>= 1.4.6)
     haml (3.1.4)
+    i18n (0.6.1)
     json (1.6.5)
+    multi_json (1.3.6)
     nokogiri (1.5.2)
     rack (1.4.1)
     rack-protection (1.2.0)
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
+    rrd-ffi (0.2.12)
+      activesupport
+      ffi
     rspec (2.9.0)
       rspec-core (~> 2.9.0)
       rspec-expectations (~> 2.9.0)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,7 +9,7 @@ app_file = @root.join('lib/visage-app')
 require 'rack/test'
 require 'webrat'
 
-ENV['CONFIG_PATH'] = @root.join('features/support/config/default')
+ENV['CONFIG_PATH'] = @root.join('features/support/config/default').to_s
 
 require app_file
 # Force the application name because polyglot breaks the auto-detection logic.

--- a/visage-app.gemspec
+++ b/visage-app.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency     "sinatra",   "= 1.3.2"
   s.add_runtime_dependency     "errand",    "= 0.7.3"
   s.add_runtime_dependency     "yajl-ruby", "= 1.1.0"
+  s.add_runtime_dependency     "rrd-ffi",   "= 0.2.12"
   s.add_development_dependency "shotgun",   ">= 0"
   s.add_development_dependency "rack-test", ">= 0"
   s.add_development_dependency "rspec",     ">= 0"


### PR DESCRIPTION
needed to run specs in 1.9.3.

Otherwise you get an error something like

can't convert Pathname into String (TypeError)

``` ruby
ENV['CONFIG_PATH'] = @root.join('features/support/config/default').to_s
```
- Added rrd-ffi to gem dependencies. as discussed
  https://github.com/auxesis/visage/issues/76

---

NOTE: you still need to install librrd-dev{el} via package manager. otherwise you get an error like

```
Could not open library 'rrd': rrd: cannot open shared object file: No such file or directory.
Could not open library 'librrd.so': librrd.so: cannot open shared object file: No such file or directory (LoadError)
```

Alternatively you can use the rrdlib gem and get a compile error when building native extensions ( when the library is missing).

---

NOTE: your tests depend on collectd

```
No such file or directory - /usr/share/collectd/types.db (Errno::ENOENT) 
```
