### PR TITLE
Debian's Apache >= 2.4 changed site config names

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ To do this on Debian/Ubuntu:
 
 ``` bash
 sudo -s
-visage-app genapache > /etc/apache2/sites-available/visage
+visage-app genapache > /etc/apache2/sites-available/visage.conf
 a2ensite visage
-a2dissite default
+a2dissite 000-default
 service apache2 reload
 ```
 


### PR DESCRIPTION
Quoting /usr/share/doc/apache2/NEWS.Debian.gz on my Ubuntu machine:

> apache2 (2.4.1-1) unstable; urgency=low
> ...
> Moreover, the configuration mechanism in Debian has changed. All
> configurations in sites-enabled and conf-enabled need a ".conf" suffix now.
> ...
> Note this means all existing sites are ignored until they get a ".conf"
> suffix and are re-enabled by the use of a2ensite. The script in [3] can
> automate that for simple cases. This change also includes Debian default
> sites, so the default site has been renamed to 000-default to avoid naming
> confusions.

BTW `a2ensite` accepts the site name without the .conf suffix, I checked.

My experiments on Ubuntu 12.04 (with Apache 2.2, still using the older conventions) show that `a2dissite 000-default` tries to disable the site called `default` and finds it's already disabled.  So it might work for all the users.  I haven't actually tried it out in a fresh Vagrant VM to see if it would successfully disable the default site, because Vagrant is annoying today.
